### PR TITLE
moved bottom wall size text

### DIFF
--- a/sources/openjscad/smartcore-v1.0.1.jscad
+++ b/sources/openjscad/smartcore-v1.0.1.jscad
@@ -972,7 +972,7 @@ function wallSizeText(){
         // right
         text3d("right: "+(_globalDepth+_wallThickness)+" x "+_globalHeight).scale(0.5).rotateX(90).rotateZ(90).translate([_globalWidth/2+_wallThickness+3,0,_globalHeight/2]).setColor(0.2,0.3,0.2),
         // bottom
-        text3d("bottom: "+(_globalWidth+(_wallThickness*2))+" x "+(_globalDepth+_wallThickness)).scale(0.5).translate([0,-_globalDepth/2,_wallThickness]).setColor(0.2,0.3,0.2)
+        text3d("bottom: "+(_globalWidth+(_wallThickness*2))+" x "+(_globalDepth+_wallThickness)).scale(0.5).translate([0,-_globalDepth/2-20,_wallThickness]).setColor(0.2,0.3,0.2)
 
     )
 }


### PR DESCRIPTION
bottom wall text was partially hidden by the left wall.  
before
![fter](https://cloud.githubusercontent.com/assets/8762862/7383800/78bc522e-edda-11e4-8117-fb8e82e5d841.png)

after
![openjscad_org_and_quillford_on_freenode_irc_network_ __reprap__526_users_](https://cloud.githubusercontent.com/assets/8762862/7383798/6ed1b682-edda-11e4-9db7-9cff89203ad7.png)
