### PR TITLE
Fixes #18 - Y-Slide bearing screws don't fit with 8mm rods

### DIFF
--- a/sources/openjscad/smartcore-v1.2.jscad
+++ b/sources/openjscad/smartcore-v1.2.jscad
@@ -323,8 +323,8 @@ var mesh;
         cylinder({r:1.3,h:Y,fn:_globalResolution}).rotateX(-90).translate([X+10,0,Z+5]),
 
         // screws for rod Y support
-        cylinder({r:1.3,h:20,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,-5,0]),
-        cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,15,-20])
+        cylinder({r:1.3,h:20,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 3,-5,0]),
+        cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 3,15,-20])
         
 
     );
@@ -363,8 +363,8 @@ var mesh;
                 ),
                 // extra part for endstop Y click
                 difference(
-                    cube({size:[(_XYlmDiam/1.5),Y-10,10]}).translate([(-_XYlmDiam/5) - 1,Y-(Y-10),-8]),
-                    cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,15,-20])
+                    cube({size:[(_XYlmDiam/2) + 2,Y-10,10]}).translate([(-_XYlmDiam/5) - 1,Y-(Y-10),-8]),
+                    cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 3,15,-20])
                 )
             );
     }

--- a/sources/openjscad/smartcore-v1.2.jscad
+++ b/sources/openjscad/smartcore-v1.2.jscad
@@ -289,7 +289,7 @@ var mesh;
 
             //extra rod Y support
             cylinder({r:_XYlmDiam/2+3.5,h:Y+10,fn:_globalResolution}).rotateX(-90).translate([14,-10,5]),
-            cube({size:[10,Y+10,6]}).translate([0,-10,2])
+            cube({size:[_XYlmDiam,Y+10,6]}).translate([-_XYlmDiam/4,-10,2])
 
 
         ),
@@ -323,8 +323,8 @@ var mesh;
         cylinder({r:1.3,h:Y,fn:_globalResolution}).rotateX(-90).translate([X+10,0,Z+5]),
 
         // screws for rod Y support
-        cylinder({r:1.3,h:20,fn:_globalResolution}).translate([3-(_XYlmDiam/4-3),-5,0]),
-        cylinder({r:1.3,h:30,fn:_globalResolution}).translate([3-(_XYlmDiam/4-3),15,-20])
+        cylinder({r:1.3,h:20,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,-5,0]),
+        cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,15,-20])
         
 
     );
@@ -363,11 +363,10 @@ var mesh;
                 ),
                 // extra part for endstop Y click
                 difference(
-					cube({size:[_XYlmDiam/2,Y-10,10]}).translate([0,Y-(Y-10),-8]),
-					cylinder({r:1.3,h:30,fn:_globalResolution}).translate([3-(_XYlmDiam/4-3),15,-20])
-				)
-        
-                );
+                    cube({size:[(_XYlmDiam/1.5),Y-10,10]}).translate([(-_XYlmDiam/5) - 1,Y-(Y-10),-8]),
+                    cylinder({r:1.3,h:30,fn:_globalResolution}).translate([(-_XYlmDiam/5) + 4,15,-20])
+                )
+            );
     }
     
     if(output==0){


### PR DESCRIPTION
This change bases the screw plate size on the bearing diameter. This _could_ be better, but it works well enough for 6mm and 8mm. Note: This does not fix the L/R lettering.
# 6mm

![image](https://cloud.githubusercontent.com/assets/505322/8525762/a70f654a-23b7-11e5-9cff-7922bf7bbf6f.png)

![image](https://cloud.githubusercontent.com/assets/505322/8525767/b037455c-23b7-11e5-9d98-b5b649a77bad.png)
# 8mm

![image](https://cloud.githubusercontent.com/assets/505322/8525785/c9fd6aca-23b7-11e5-9617-751d6401ea58.png)
![image](https://cloud.githubusercontent.com/assets/505322/8525797/d612ec04-23b7-11e5-989a-9bd6712c8ea3.png)
